### PR TITLE
Use Traefik (instead of Nginx) as Reverse Proxy

### DIFF
--- a/docker-compose/docker-compose-linux.yml
+++ b/docker-compose/docker-compose-linux.yml
@@ -9,7 +9,8 @@ services:
     volumes:
       - "./traefik/traefik-static.toml:/etc/traefik/traefik.toml"
       - "./traefik/traefik-dynamic-linux.toml:/etc/traefik/traefik-dynamic.toml"
-
+    network_mode: "host"
+    
    mongo-auth:
     image: mongo
     container_name: explorviz-auth-mongo

--- a/docker-compose/docker-compose-linux.yml
+++ b/docker-compose/docker-compose-linux.yml
@@ -2,9 +2,13 @@ version: "3.2"
 services:
 
    reverse-proxy:
-    image: explorviz/reverse-proxy:latest
-    container_name: explorviz-reverse-proxy
-    network_mode: "host"
+    image: "traefik:v2.0.1"
+    container_name: "explorviz-reverse-proxy"
+    ports:
+      - "8080:8080"
+    volumes:
+      - "./traefik/traefik-static.toml:/etc/traefik/traefik.toml"
+      - "./traefik/traefik-dynamic-linux.toml:/etc/traefik/traefik-dynamic.toml"
 
    mongo-auth:
     image: mongo

--- a/docker-compose/docker-compose-windows-mac.yml
+++ b/docker-compose/docker-compose-windows-mac.yml
@@ -3,10 +3,13 @@ version: "3.2"
 services:
 
   reverse-proxy:
-    image: explorviz/reverse-proxy:macos
-    container_name: explorviz-reverse-proxy
+    image: "traefik:v2.0.1"
+    container_name: "explorviz-reverse-proxy"
     ports:
-      - 8080:8080
+      - "8080:8080"
+    volumes:
+      - "./traefik/traefik-static.toml:/etc/traefik/traefik.toml"
+      - "./traefik/traefik-dynamic-mac-windows.toml:/etc/traefik/traefik-dynamic.toml"
 
   mongo-auth:
     image: mongo

--- a/docker-compose/traefik/traefik-dynamic-linux.toml
+++ b/docker-compose/traefik/traefik-dynamic-linux.toml
@@ -1,0 +1,44 @@
+[http.routers]
+
+  [http.routers.broadcast]
+    rule = "PathPrefix(`/v1/landscapes/broadcast`)"
+    service = "broadcast"
+    priority = 200
+
+  [http.routers.discovery]
+    rule = "PathPrefix(`/v1/agents`)"
+    service = "discovery"
+
+  [http.routers.history]
+    rule = "PathPrefix(`/v1/landscapes`) || PathPrefix(`/v1/timestamps`)"
+    service = "history"
+
+  [http.routers.settings]
+    rule = "PathPrefix(`/v1/settings/info`) || PathPrefix(`/v1/users/{uid}/settings`) || PathPrefix(`/v1/settings/preferences`)"
+    service = "settings"
+
+  [http.routers.user]
+    rule = "PathPrefix(`/v1/tokens`) || PathPrefix(`/v1/users`)"
+    service = "user"
+
+[http.services]
+
+  [http.services.broadcast]  
+    [[http.services.broadcast.loadBalancer.servers]]
+      url = "http://localhost:8081"
+
+  [http.services.discovery]  
+    [[http.services.discovery.loadBalancer.servers]]
+      url = "http://localhost:8083"
+
+  [http.services.history]  
+    [[http.services.history.loadBalancer.servers]]
+      url = "http://localhost:8086"
+
+  [http.services.settings]  
+    [[http.services.settings.loadBalancer.servers]]
+      url = "http://localhost:8087"
+
+  [http.services.user]  
+    [[http.services.user.loadBalancer.servers]]
+      url = "http://localhost:8082"

--- a/docker-compose/traefik/traefik-dynamic-mac-windows.toml
+++ b/docker-compose/traefik/traefik-dynamic-mac-windows.toml
@@ -1,0 +1,44 @@
+[http.routers]
+
+  [http.routers.broadcast]
+    rule = "PathPrefix(`/v1/landscapes/broadcast`)"
+    service = "broadcast"
+    priority = 200
+
+  [http.routers.discovery]
+    rule = "PathPrefix(`/v1/agents`)"
+    service = "discovery"
+
+  [http.routers.history]
+    rule = "PathPrefix(`/v1/landscapes`) || PathPrefix(`/v1/timestamps`)"
+    service = "history"
+
+  [http.routers.settings]
+    rule = "PathPrefix(`/v1/settings/info`) || PathPrefix(`/v1/users/{uid}/settings`) || PathPrefix(`/v1/settings/preferences`)"
+    service = "settings"
+
+  [http.routers.user]
+    rule = "PathPrefix(`/v1/tokens`) || PathPrefix(`/v1/users`)"
+    service = "user"
+
+[http.services]
+
+  [http.services.broadcast]  
+    [[http.services.broadcast.loadBalancer.servers]]
+      url = "http://host.docker.internal:8081"
+
+  [http.services.discovery]  
+    [[http.services.discovery.loadBalancer.servers]]
+      url = "http://host.docker.internal:8083"
+
+  [http.services.history]  
+    [[http.services.history.loadBalancer.servers]]
+      url = "http://host.docker.internal:8086"
+
+  [http.services.settings]  
+    [[http.services.settings.loadBalancer.servers]]
+      url = "http://host.docker.internal:8087"
+
+  [http.services.user]  
+    [[http.services.user.loadBalancer.servers]]
+      url = "http://host.docker.internal:8082"

--- a/docker-compose/traefik/traefik-static.toml
+++ b/docker-compose/traefik/traefik-static.toml
@@ -1,0 +1,10 @@
+# Static Configuration
+[providers]
+  [providers.file]
+    directory = "/etc/traefik"
+    watch = true
+    filename = "traefik-dynamic.toml"
+
+[api]
+  insecure = true
+  dashboard = true


### PR DESCRIPTION
**Problem 1 (general)**: The Nginx Reverse Proxy fails, if some upstreams are not present during its startup phase. Previous tests with variables (https://github.com/ExplorViz/reverse-proxy/commit/ed26218977c17d227afbe3538ecf02b03f21a4e9) work for common HTTP methods, but fail for SSE and HTTP Patch requests.

**Problem 2**: With Nginx, Extensions of ExplorViz require a modified nginx.conf file upon deployment. This is an absolute pain, since we somehow must provide these files for different configurations of core and extensions.

**Problem 3**: During the refactoring of https://github.com/ExplorViz/explorviz-backend/pull/98, more precisely the `apiTest` source set, I saw that we finally need a dynamic reverse proxy, since we do not require to boot up the whole ExplorViz Stack for all tests, but only a few services and auxiliary software. For example: The user tests do not require the broadcast-service up and running, but the Reverse Proxy (that should be used in the API tests) does.

**Solution**: Traefik allows the proxy setup via multiple ways, e.g., [Docker Labels](https://github.com/ExplorViz/docker-configuration/blob/master/docker-compose-1.4.0-traefik.yml) or config files (this PR). We can therefore use Traefik as complete (and way better) replacement of Nginx (in development, API tests, Docker deployment). 

@lotzk Can you verify the Linux version of this new approach? Works in my Ubuntu VM though. Simply boot up the docker-compose (from inside the docker-compose folder) and the frontend and check if it works as expected.