### PR TITLE
Update SpotBugs version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ subprojects {
         }
     }
     dependencies {
-        classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.3"
+        classpath "com.github.spotbugs:spotbugs-gradle-plugin:2.0.1"
     }
   }
   


### PR DESCRIPTION
The currently used SpotBugs gradle plugin uses soon to-be removed gradle features. This PR updates the plugin to a newer version.