### PR TITLE
Issue/118- Fix URI inconsistencies

### DIFF
--- a/docker-compose/docker-compose-api-test.yml
+++ b/docker-compose/docker-compose-api-test.yml
@@ -27,7 +27,8 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.port=8082"
-      - "traefik.http.routers.user-service.rule=PathPrefix(`/v1/tokens`) || PathPrefix(`/v1/users`) || PathPrefix(`/v1/roles`)"
+      - "traefik.http.routers.user-service.rule=PathPrefix(`/v1/tokens`) ||
+          PathPrefix(`/v1/users`) || PathPrefix(`/v1/roles`) || PathPrefix(`/v1/userbatch`)"
     networks:
       - explorviz
 

--- a/docker-compose/docker-compose-api-test.yml
+++ b/docker-compose/docker-compose-api-test.yml
@@ -42,7 +42,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.port=8087"
-      - "traefik.http.routers.settings-service.rule=PathPrefix(`/v1/settings`) || PathPrefix(`/v1/users/{uid}/settings`) || PathPrefix(`/v1/users/settings/preferences`)"
+      - "traefik.http.routers.settings-service.rule=PathPrefix(`/v1/settings`) || PathPrefix(`/v1/preferences`)"
     networks:
       - explorviz
 

--- a/docker-compose/traefik/traefik-dynamic-linux.toml
+++ b/docker-compose/traefik/traefik-dynamic-linux.toml
@@ -14,7 +14,7 @@
     service = "history"
 
   [http.routers.settings]
-    rule = "PathPrefix(`/v1/settings/info`) || PathPrefix(`/v1/users/{uid}/settings`) || PathPrefix(`/v1/users/settings/preferences`)"
+    rule = "PathPrefix(`/v1/settings/`) || PathPrefix(`/v1/users/{uid}/preferences`) || PathPrefix(`/v1/preferences`)"
     service = "settings"
 
   [http.routers.user]

--- a/docker-compose/traefik/traefik-dynamic-linux.toml
+++ b/docker-compose/traefik/traefik-dynamic-linux.toml
@@ -14,11 +14,11 @@
     service = "history"
 
   [http.routers.settings]
-    rule = "PathPrefix(`/v1/settings/`) || PathPrefix(`/v1/users/{uid}/preferences`) || PathPrefix(`/v1/preferences`)"
+    rule = "PathPrefix(`/v1/settings`) || PathPrefix(`/v1/preferences`)"
     service = "settings"
 
   [http.routers.user]
-    rule = "PathPrefix(`/v1/tokens`) || PathPrefix(`/v1/users`) || PathPrefix(`/v1/roles`)"
+    rule = "PathPrefix(`/v1/tokens`) || PathPrefix(`/v1/users`) || PathPrefix(`/v1/roles`) || PathPrefix(`/v1/userbatch`)"
     service = "user"
 
 [http.services]

--- a/docker-compose/traefik/traefik-dynamic-mac-windows.toml
+++ b/docker-compose/traefik/traefik-dynamic-mac-windows.toml
@@ -14,7 +14,7 @@
     service = "history"
 
   [http.routers.settings]
-    rule = "PathPrefix(`/v1/settings/info`) || PathPrefix(`/v1/users/{uid}/settings`) || PathPrefix(`/v1/users/settings/preferences`)"
+    rule = "PathPrefix(`/v1/settings/`) || PathPrefix(`/v1/users/{uid}/preferences`) || PathPrefix(`/v1/preferences`)"
     service = "settings"
 
   [http.routers.user]

--- a/docker-compose/traefik/traefik-dynamic-mac-windows.toml
+++ b/docker-compose/traefik/traefik-dynamic-mac-windows.toml
@@ -14,11 +14,11 @@
     service = "history"
 
   [http.routers.settings]
-    rule = "PathPrefix(`/v1/settings/`) || PathPrefix(`/v1/users/{uid}/preferences`) || PathPrefix(`/v1/preferences`)"
+    rule = "PathPrefix(`/v1/settings`) || PathPrefix(`/v1/preferences`)"
     service = "settings"
 
   [http.routers.user]
-    rule = "PathPrefix(`/v1/tokens`) || PathPrefix(`/v1/users`) || PathPrefix(`/v1/roles`)"
+    rule = "PathPrefix(`/v1/tokens`) || PathPrefix(`/v1/users`) || PathPrefix(`/v1/roles`) || PathPrefix(`/v1/userbatch`)"
     service = "user"
 
 [http.services]

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Use remote shared project if set to true.
 # Use local linked project (must be at the same root parent folder) if set to false.
 # This flag is used in the settings.gradle and build.gradle files.
-useRemoteSharedProject=true
+useRemoteSharedProject=false
 
 # Version of the remote shared project to use.
 # https://github.com/ExplorViz/explorviz-backend-shared

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Use remote shared project if set to true.
 # Use local linked project (must be at the same root parent folder) if set to false.
 # This flag is used in the settings.gradle and build.gradle files.
-useRemoteSharedProject=false
+useRemoteSharedProject=true
 
 # Version of the remote shared project to use.
 # https://github.com/ExplorViz/explorviz-backend-shared

--- a/settings-service/src/apiTest/java/net/explorviz/settings/server/resources/test/PreferenceCreation.java
+++ b/settings-service/src/apiTest/java/net/explorviz/settings/server/resources/test/PreferenceCreation.java
@@ -17,7 +17,7 @@ public class PreferenceCreation {
 
   // private static final String USER_PREF_URL =
   // "http://localhost:8090/v1/users/{uid}/settings/preferences";
-  private static final String PREF_URL = "http://localhost:8090/v1/users/settings/preferences";
+  private static final String PREF_URL = "http://localhost:8090/v1/preferences";
 
   private static String adminToken;
   private static String normieToken;

--- a/settings-service/src/apiTest/java/net/explorviz/settings/server/resources/test/PreferenceDeletion.java
+++ b/settings-service/src/apiTest/java/net/explorviz/settings/server/resources/test/PreferenceDeletion.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.Test;
 class PreferenceDeletion {
 
   private static final String USER_PREF_URL =
-      "http://localhost:8090/v1/users/{uid}/settings/preferences";
-  private static final String PREF_URL = "http://localhost:8090/v1/users/settings/preferences";
+          "http://localhost:8090/v1/preferences?filter[user]={uid}";
+  private static final String PREF_URL = "http://localhost:8090/v1/preferences";
 
   private static String adminToken;
   private static String normieToken;

--- a/settings-service/src/apiTest/java/net/explorviz/settings/server/resources/test/PreferenceRetrieval.java
+++ b/settings-service/src/apiTest/java/net/explorviz/settings/server/resources/test/PreferenceRetrieval.java
@@ -20,8 +20,8 @@ import org.junit.jupiter.api.Test;
 public class PreferenceRetrieval {
 
   private static final String USER_PREF_URL =
-      "http://localhost:8090/v1/users/{uid}/settings/preferences";
-  private static final String PREF_URL = "http://localhost:8090/v1/users/settings/preferences";
+          "http://localhost:8090/v1/preferences?filter[user]={uid}";
+  private static final String PREF_URL = "http://localhost:8090/v1/preferences";
 
   private static String adminToken;
   private static String normieToken;

--- a/settings-service/src/apiTest/java/net/explorviz/settings/server/resources/test/PreferenceUpdate.java
+++ b/settings-service/src/apiTest/java/net/explorviz/settings/server/resources/test/PreferenceUpdate.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.Test;
 class PreferenceUpdate {
 
   private static final String USER_PREF_URL =
-      "http://localhost:8090/v1/users/{uid}/settings/preferences";
-  private static final String PREF_URL = "http://localhost:8090/v1/users/settings/preferences";
+          "http://localhost:8090/v1/preferences?filter[user]={uid}";
+  private static final String PREF_URL = "http://localhost:8090/v1/preferences";
 
   private static String adminToken;
   private static String normieToken;

--- a/settings-service/src/apiTest/java/net/explorviz/settings/server/resources/test/SettingsInfoCreation.java
+++ b/settings-service/src/apiTest/java/net/explorviz/settings/server/resources/test/SettingsInfoCreation.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 
 class SettingsInfoCreation {
 
-  private static final String SETTINGS_URL = "http://localhost:8090/v1/settings/info";
+  private static final String SETTINGS_URL = "http://localhost:8090/v1/settings";
 
   private static String adminToken;
   private static String normieToken;

--- a/settings-service/src/apiTest/java/net/explorviz/settings/server/resources/test/SettingsInfoDeletion.java
+++ b/settings-service/src/apiTest/java/net/explorviz/settings/server/resources/test/SettingsInfoDeletion.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 
 class SettingsInfoDeletion {
 
-  private static final String SETTINGS_URL = "http://localhost:8090/v1/settings/info";
+  private static final String SETTINGS_URL = "http://localhost:8090/v1/settings";
 
   private static String adminToken;
   private static String normieToken;

--- a/settings-service/src/apiTest/java/net/explorviz/settings/server/resources/test/SettingsInfoRetrieval.java
+++ b/settings-service/src/apiTest/java/net/explorviz/settings/server/resources/test/SettingsInfoRetrieval.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 public class SettingsInfoRetrieval {
 
-  private static final String SETTINGS_URL = "http://localhost:8090/v1/settings/info";
+  private static final String SETTINGS_URL = "http://localhost:8090/v1/settings";
 
   private static String adminToken;
   private static String normieToken;

--- a/settings-service/src/main/java/net/explorviz/settings/server/main/Application.java
+++ b/settings-service/src/main/java/net/explorviz/settings/server/main/Application.java
@@ -7,7 +7,7 @@ import net.explorviz.settings.model.UserPreference;
 import net.explorviz.settings.server.providers.SettingJsonApiDeserializer;
 import net.explorviz.settings.server.providers.UserSettingJsonApiDeserializer;
 import net.explorviz.settings.server.resources.EntryPointResource;
-import net.explorviz.settings.server.resources.SettingsInfoResource;
+import net.explorviz.settings.server.resources.SettingsResource;
 import net.explorviz.settings.server.resources.UserPreferencesResource;
 import net.explorviz.shared.common.jsonapi.ResourceConverterFactory;
 import net.explorviz.shared.common.provider.GenericTypeFinder;
@@ -62,7 +62,7 @@ public class Application extends ResourceConfig {
     this.register(SetupApplicationListener.class);
 
     // register all resources
-    this.register(SettingsInfoResource.class);
+    this.register(SettingsResource.class);
     this.register(UserPreferencesResource.class);
     this.register(EntryPointResource.class);
 

--- a/settings-service/src/main/java/net/explorviz/settings/server/resources/SettingsInfoResource.java
+++ b/settings-service/src/main/java/net/explorviz/settings/server/resources/SettingsInfoResource.java
@@ -40,7 +40,7 @@ import net.explorviz.shared.security.filters.Secure;
  * API for handling {@link Setting}s and their associated information.
  *
  */
-@Path("v1/settings/info")
+@Path("v1/settings")
 @Tag(name = "Settings")
 @SecurityScheme(type = SecuritySchemeType.HTTP, name = "token", scheme = "bearer",
     bearerFormat = "JWT")

--- a/settings-service/src/main/java/net/explorviz/settings/server/resources/SettingsResource.java
+++ b/settings-service/src/main/java/net/explorviz/settings/server/resources/SettingsResource.java
@@ -46,7 +46,7 @@ import net.explorviz.shared.security.filters.Secure;
     bearerFormat = "JWT")
 @SecurityRequirement(name = "token")
 @Secure
-public class SettingsInfoResource {
+public class SettingsResource {
 
   private static final String MEDIA_TYPE = "application/vnd.api+json";
 
@@ -54,7 +54,7 @@ public class SettingsInfoResource {
   private final SettingsRepository repo;
 
   @Inject
-  public SettingsInfoResource(final SettingsRepository repo) {
+  public SettingsResource(final SettingsRepository repo) {
     this.repo = repo;
   }
 

--- a/settings-service/src/main/java/net/explorviz/settings/server/resources/UserPreferencesResource.java
+++ b/settings-service/src/main/java/net/explorviz/settings/server/resources/UserPreferencesResource.java
@@ -88,7 +88,7 @@ public class UserPreferencesResource {
   @GET
   @Produces(MEDIA_TYPE)
   @PermitAll
-  @Path("{uid}/settings/preferences")
+  @Path("{uid}/preferences")
   @Operation(summary = "Get a user's preferences")
   @ApiResponse(responseCode = "200",
       description = "Return all preferences of the user with the given id.", content = @Content(
@@ -132,7 +132,7 @@ public class UserPreferencesResource {
    */
   @DELETE
   @PermitAll
-  @Path("settings/preferences/{id}")
+  @Path("/preferences/{id}")
   @Operation(summary = "Delete a preference",
       description = "If a preference is delete, the default value of the corresponding "
           + "setting applies again.")
@@ -169,7 +169,7 @@ public class UserPreferencesResource {
    */
   @PATCH
   @Produces(MEDIA_TYPE)
-  @Path("settings/preferences/{prefId}")
+  @Path("/preferences/{prefId}")
   @PermitAll
   @Operation(summary = "Update a preference value")
   @ApiResponse(responseCode = "200",
@@ -235,7 +235,7 @@ public class UserPreferencesResource {
   @POST
   @Consumes(MEDIA_TYPE)
   @PermitAll
-  @Path("settings/preferences")
+  @Path("/preferences")
   @Operation(summary = "Create a preference value")
   @ApiResponse(responseCode = "200",
       description = "Value was updated, the repsonse contains the update preference.",

--- a/settings-service/src/main/java/net/explorviz/settings/server/resources/UserPreferencesResource.java
+++ b/settings-service/src/main/java/net/explorviz/settings/server/resources/UserPreferencesResource.java
@@ -12,8 +12,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Arrays;
+import java.util.Optional;
 import javax.annotation.security.PermitAll;
 import javax.inject.Inject;
+import javax.swing.text.html.Option;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -44,10 +46,11 @@ import org.slf4j.LoggerFactory;
  * Resource to access {@link UserPreference}, i.e. to handle user specific settings.
  *
  */
-@Path("v1/users")
+@Path("/v1/preferences")
 @Tag(name = "Preferences")
 @SecurityRequirement(name = "token")
 @Secure
+@PermitAll
 public class UserPreferencesResource {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UserPreferencesResource.class);
@@ -80,15 +83,13 @@ public class UserPreferencesResource {
   }
 
   /**
-   * Access preferences of a user.
+   * Access all preferences, possible filtered for a specific of a user.
    *
-   * @param uid query parameter that denotes the user.
    * @return a list of all user preferences for a given user.
    */
   @GET
   @Produces(MEDIA_TYPE)
   @PermitAll
-  @Path("{uid}/preferences")
   @Operation(summary = "Get a user's preferences")
   @ApiResponse(responseCode = "200",
       description = "Return all preferences of the user with the given id.", content = @Content(
@@ -99,20 +100,19 @@ public class UserPreferencesResource {
       @Parameter(in = ParameterIn.QUERY, name = "page[size]",
           description = "Controls the size, i.e., amount of entities, of each page."),
       @Parameter(in = ParameterIn.QUERY, name = "page[number]",
-          description = "Index of the page to return.")})
+          description = "Index of the page to return."),
+      @Parameter(in = ParameterIn.QUERY, name = "filter[user]",
+          description = "User id to filter preferences for")})
   public QueryResult<UserPreference> getPreferencesForUser(@Context final HttpHeaders headers,
-      @Context final UriInfo uriInfo,
-      @Parameter(description = "Id of the user") @PathParam("uid") final String uid) {
+      @Context final UriInfo uriInfo) {
 
     final Query<UserPreference> query = Query.fromParameterMap(uriInfo.getQueryParameters(true));
 
-    // Workaround to query only for a specific user
-    // Technically the path parameter 'uid' is handled as a query parameter
-    query.getFilters().put("userId", Arrays.asList(uid));
+    String uid = query.getFilters().get("user") == null?"":query.getFilters().get("user").get(0);
 
     final String authHeader = headers.getHeaderString(HttpHeaders.AUTHORIZATION);
 
-    if (!this.canAccess(authHeader, uid)) {
+    if (this.canAccess(authHeader, uid)) {
       if (LOGGER.isInfoEnabled()) {
         LOGGER.info(NO_ADMIN_MESSAGE);
       }
@@ -132,7 +132,7 @@ public class UserPreferencesResource {
    */
   @DELETE
   @PermitAll
-  @Path("/preferences/{id}")
+  @Path("/{id}")
   @Operation(summary = "Delete a preference",
       description = "If a preference is delete, the default value of the corresponding "
           + "setting applies again.")
@@ -169,7 +169,7 @@ public class UserPreferencesResource {
    */
   @PATCH
   @Produces(MEDIA_TYPE)
-  @Path("/preferences/{prefId}")
+  @Path("/{id}")
   @PermitAll
   @Operation(summary = "Update a preference value")
   @ApiResponse(responseCode = "200",
@@ -184,7 +184,7 @@ public class UserPreferencesResource {
           + "the id of the corresponding setting must stay the same.")
   public UserPreference updatePref(
       @Parameter(
-          description = "Id of the preference to update.") @PathParam("prefId") final String prefId,
+          description = "Id of the preference to update.") @PathParam("id") final String prefId,
       @Context final HttpHeaders headers, final UserPreference updatedPref) {
 
     final UserPreference found = this.userPrefRepo.find(prefId).orElseThrow(NotFoundException::new);
@@ -234,8 +234,6 @@ public class UserPreferencesResource {
    */
   @POST
   @Consumes(MEDIA_TYPE)
-  @PermitAll
-  @Path("/preferences")
   @Operation(summary = "Create a preference value")
   @ApiResponse(responseCode = "200",
       description = "Value was updated, the repsonse contains the update preference.",

--- a/settings-service/src/main/java/net/explorviz/settings/server/resources/UserPreferencesResource.java
+++ b/settings-service/src/main/java/net/explorviz/settings/server/resources/UserPreferencesResource.java
@@ -112,7 +112,7 @@ public class UserPreferencesResource {
 
     final String authHeader = headers.getHeaderString(HttpHeaders.AUTHORIZATION);
 
-    if (this.canAccess(authHeader, uid)) {
+    if (!this.canAccess(authHeader, uid)) {
       if (LOGGER.isInfoEnabled()) {
         LOGGER.info(NO_ADMIN_MESSAGE);
       }

--- a/settings-service/src/main/java/net/explorviz/settings/services/AuthorizationService.java
+++ b/settings-service/src/main/java/net/explorviz/settings/services/AuthorizationService.java
@@ -29,7 +29,7 @@ public class AuthorizationService {
   public boolean isSameUser(final String uid, final String authHeader) {
     try {
       final TokenDetails details = this.tps.parseToken(authHeader.substring(7));
-      return details.getUserId().equals(uid);
+      return details.getUserId().contentEquals(uid);
     } catch (final NullPointerException e) {
       // No token given
       return false;

--- a/settings-service/src/main/java/net/explorviz/settings/services/UserPreferenceRepository.java
+++ b/settings-service/src/main/java/net/explorviz/settings/services/UserPreferenceRepository.java
@@ -99,13 +99,14 @@ public class UserPreferenceRepository
   @Override
   public QueryResult<UserPreference> query(final Query<UserPreference> query) {
     final String userIdField = "userId";
+    final String userFilterField = "user";
 
     final xyz.morphia.query.Query<UserPreference> q =
         this.datastore.createQuery(UserPreference.class);
 
 
     // Filter for user
-    final List<String> userFilter = query.getFilters().get(userIdField);
+    final List<String> userFilter = query.getFilters().get(userFilterField);
 
     if (userFilter != null && userFilter.size() == 1) {
       q.field(userIdField).contains(userFilter.get(0));

--- a/user-service/src/apiTest/java/net/explorviz/security/server/resources/test/BatchRequest.java
+++ b/user-service/src/apiTest/java/net/explorviz/security/server/resources/test/BatchRequest.java
@@ -28,10 +28,10 @@ import org.junit.jupiter.api.Test;
 
 public class BatchRequest {
 
-  private static final String BATCH_URL = "http://localhost:8090/v1/users/batch";
+  private static final String BATCH_URL = "http://localhost:8090/v1/userbatch";
   private static final String USER_URL = "http://localhost:8090/v1/users/";
   private static final String PREF_URL =
-      "http://localhost:8090/v1/users/{uid}/settings/preferences";
+      "http://localhost:8090/v1/preferences?filter[user]={uid}";
 
   private static String adminToken;
   private static String normieToken;

--- a/user-service/src/apiTest/java/net/explorviz/security/server/resources/test/BatchRequest.java
+++ b/user-service/src/apiTest/java/net/explorviz/security/server/resources/test/BatchRequest.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import net.explorviz.security.model.UserBatchRequest;
-import net.explorviz.security.server.resources.BatchRequestSubResource;
+import net.explorviz.security.server.resources.BatchRequestResource;
 import net.explorviz.security.server.resources.test.helper.AuthorizationHelper;
 import net.explorviz.security.server.resources.test.helper.JsonAPIListMapper;
 import net.explorviz.security.server.resources.test.helper.JsonAPIMapper;
@@ -222,7 +222,7 @@ public class BatchRequest {
 
   @Test
   void countLimit() {
-    final int count = BatchRequestSubResource.MAX_COUNT + 1;
+    final int count = BatchRequestResource.MAX_COUNT + 1;
     final List<String> passwords = IntStream.range(0, count)
         .mapToObj(i -> RandomStringUtils.random(5, "abcdefghijklmnopqrstuvwxyz"))
         .collect(Collectors.toList());

--- a/user-service/src/main/java/net/explorviz/security/server/main/Application.java
+++ b/user-service/src/main/java/net/explorviz/security/server/main/Application.java
@@ -3,10 +3,7 @@ package net.explorviz.security.server.main;
 import net.explorviz.security.model.UserBatchRequest;
 import net.explorviz.security.server.providers.GenericJsonApiPaginationWriter;
 import net.explorviz.security.server.providers.UserJsonApiDeserializer;
-import net.explorviz.security.server.resources.EntryPointResource;
-import net.explorviz.security.server.resources.RoleResource;
-import net.explorviz.security.server.resources.TokenResource;
-import net.explorviz.security.server.resources.UserResource;
+import net.explorviz.security.server.resources.*;
 import net.explorviz.security.user.Role;
 import net.explorviz.security.user.User;
 import net.explorviz.settings.model.UserPreference;
@@ -75,6 +72,7 @@ public class Application extends ResourceConfig {
     this.register(TokenResource.class);
     this.register(UserResource.class);
     this.register(RoleResource.class);
+    this.register(BatchRequestResource.class);
     this.register(EntryPointResource.class);
 
     this.packages("io.swagger.v3.jaxrs2.integration.resources");

--- a/user-service/src/main/java/net/explorviz/security/server/main/DependencyInjectionBinder.java
+++ b/user-service/src/main/java/net/explorviz/security/server/main/DependencyInjectionBinder.java
@@ -3,7 +3,7 @@ package net.explorviz.security.server.main;
 import javax.inject.Singleton;
 import net.explorviz.security.injection.KafkaProducerFactory;
 import net.explorviz.security.server.injection.DatastoreFactory;
-import net.explorviz.security.server.resources.BatchRequestSubResource;
+import net.explorviz.security.server.resources.BatchRequestResource;
 import net.explorviz.security.services.BatchService;
 import net.explorviz.security.services.KafkaUserService;
 import net.explorviz.security.services.TokenService;
@@ -39,7 +39,7 @@ public class DependencyInjectionBinder extends CommonDependencyInjectionBinder {
 
     this.bind(IdGenerator.class).to(IdGenerator.class).in(Singleton.class);
     this.bind(BatchService.class).to(BatchService.class).in(Singleton.class);
-    this.bind(BatchRequestSubResource.class).to(BatchRequestSubResource.class).in(Singleton.class);
+    this.bind(BatchRequestResource.class).to(BatchRequestResource.class).in(Singleton.class);
 
   }
 }

--- a/user-service/src/main/java/net/explorviz/security/server/resources/BatchRequestResource.java
+++ b/user-service/src/main/java/net/explorviz/security/server/resources/BatchRequestResource.java
@@ -40,9 +40,10 @@ import org.slf4j.LoggerFactory;
 @Tags(value = {@Tag(name = "Batch"), @Tag(name = "User")})
 @SecurityRequirement(name = "token")
 @Secure
-public class BatchRequestSubResource {
+@Path("v1/userbatch")
+public class BatchRequestResource {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(BatchRequestSubResource.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(BatchRequestResource.class);
 
   private static final String MEDIA_TYPE = "application/vnd.api+json";
   public static final int MAX_COUNT = 300;
@@ -51,7 +52,7 @@ public class BatchRequestSubResource {
   private final BatchService bcs;
 
   @Inject
-  public BatchRequestSubResource(final BatchService batchCreationService) {
+  public BatchRequestResource(final BatchService batchCreationService) {
     this.bcs = batchCreationService;
   }
 

--- a/user-service/src/main/java/net/explorviz/security/server/resources/UserResource.java
+++ b/user-service/src/main/java/net/explorviz/security/server/resources/UserResource.java
@@ -71,7 +71,7 @@ public class UserResource {
   private final UserService userCrudService;
 
 
-  private final BatchRequestSubResource batchSubResource;
+  private final BatchRequestResource batchSubResource;
 
   /**
    * Constructor for this class.
@@ -81,7 +81,7 @@ public class UserResource {
    */
   @Inject
   public UserResource(final UserService userCrudService,
-      final BatchRequestSubResource batchSubResource) {
+      final BatchRequestResource batchSubResource) {
     this.userCrudService = userCrudService;
     this.batchSubResource = batchSubResource;
   }
@@ -148,13 +148,6 @@ public class UserResource {
       LOGGER.error("Error saving user", ex);
       throw new InternalServerErrorException();
     }
-  }
-
-
-
-  @Path("batch")
-  public BatchRequestSubResource batchRequest() {
-    return this.batchSubResource;
   }
 
   /**

--- a/user-service/src/main/resources/explorviz.production.properties
+++ b/user-service/src/main/resources/explorviz.production.properties
@@ -36,4 +36,4 @@ exchange.kafka.bootstrap.servers=localhost:9092
 # Services #
 ############
 services.settings=localhost:8087
-services.settings.preferences=v1/users/settings/preferences
+services.settings.preferences=v1/preferences

--- a/user-service/src/main/resources/explorviz.properties
+++ b/user-service/src/main/resources/explorviz.properties
@@ -34,4 +34,4 @@ exchange.kafka.bootstrap.servers=localhost:9092
 # Services #
 ############
 services.settings=localhost:8087
-services.settings.preferences=v1/users/settings/preferences
+services.settings.preferences=v1/preferences


### PR DESCRIPTION
This PR fixes some inconsistencies in the URIs as explained in #118. The following URIs are renamed:

- User Service
  - `/users/batch` -> `/userbatch`
- Settings Service
  - `/settings/info/` -> `/settings/`
  - `/users/<user-id>/settings/preferences/` -> `/preferences?filter[user]={uid}`

Traefik is already setup to forward to these URIs. The routes used in the Frontend need to be adjusted accordingly. 