### PR TITLE
Modify Dockerfiles to adhere to best practices

### DIFF
--- a/analysis-service/Dockerfile
+++ b/analysis-service/Dockerfile
@@ -1,19 +1,21 @@
-## SWITCH TO JRE AFTER ANALYSIS REBUILD
+FROM adoptopenjdk/openjdk11:alpine-slim AS extractor
 
-FROM adoptopenjdk/openjdk11:jdk-11.0.4_11-alpine-slim
-
-RUN mkdir /explorviz
-WORKDIR /explorviz
+WORKDIR /opt/explorviz
 COPY build/libs/explorviz-analysis-service.jar .
 
 # workaround due to old analysis properties
-RUN jar xf explorviz-analysis-service.jar
+RUN jar xf explorviz-analysis-service.jar \
+ && rm explorviz-analysis-service.jar
+
+FROM adoptopenjdk/openjdk11:alpine-jre
+
+RUN adduser -D -H explorviz
+
+WORKDIR /opt/explorviz
+COPY --from=extractor /opt/explorviz .
 COPY explorviz.docker.live_trace_processing.properties META-INF/explorviz.live_trace_processing.properties
 
-#COPY prod-env-updater.sh .
-#RUN chmod +x ./prod-env-updater.sh
-
-#CMD java -jar explorviz-analysis-service.jar
-
-#CMD java -cp explorviz-analysis-service.jar:META-INF net.explorviz.analysis.Main
-CMD java -cp . net.explorviz.analysis.Main
+USER explorviz
+#CMD ["java", "-jar", "explorviz-analysis-service.jar"]
+#CMD ["java", "-cp", "explorviz-analysis-service.jar:META-INF", "net.explorviz.analysis.Main"]
+CMD ["java", "-cp", ".", "net.explorviz.analysis.Main"]

--- a/broadcast-service/Dockerfile
+++ b/broadcast-service/Dockerfile
@@ -1,7 +1,9 @@
-FROM openjdk:11-jre-slim
+FROM adoptopenjdk/openjdk11:alpine-jre
 
-RUN mkdir /explorviz
-WORKDIR /explorviz
+RUN adduser -D -H explorviz
+
+WORKDIR /opt/explorviz
 COPY build/libs/explorviz-broadcast-service.jar .
 
-CMD java -jar explorviz-broadcast-service.jar
+USER explorviz
+CMD ["java", "-jar", "explorviz-broadcast-service.jar"]

--- a/discovery-service/Dockerfile
+++ b/discovery-service/Dockerfile
@@ -1,7 +1,9 @@
-FROM openjdk:11-jre-slim
+FROM adoptopenjdk/openjdk11:alpine-jre
 
-RUN mkdir /explorviz
-WORKDIR /explorviz
+RUN adduser -D -H explorviz
+
+WORKDIR /opt/explorviz
 COPY build/libs/explorviz-discovery-service.jar .
 
-CMD java -jar explorviz-discovery-service.jar
+USER explorviz
+CMD ["java", "-jar", "explorviz-discovery-service.jar"]

--- a/history-service/Dockerfile
+++ b/history-service/Dockerfile
@@ -1,7 +1,9 @@
-FROM openjdk:11-jre-slim
+FROM adoptopenjdk/openjdk11:alpine-jre
 
-RUN mkdir /explorviz
-WORKDIR /explorviz
+RUN adduser -D -H explorviz
+
+WORKDIR /opt/explorviz
 COPY build/libs/explorviz-history-service.jar .
 
-CMD java -jar explorviz-history-service.jar
+USER explorviz
+CMD ["java", "-jar", "explorviz-history-service.jar"]

--- a/landscape-service/Dockerfile
+++ b/landscape-service/Dockerfile
@@ -1,7 +1,9 @@
-FROM openjdk:11-jre-slim
+FROM adoptopenjdk/openjdk11:alpine-jre
 
-RUN mkdir /explorviz
-WORKDIR /explorviz
+RUN adduser -D -H explorviz
+
+WORKDIR /opt/explorviz
 COPY build/libs/explorviz-landscape-service.jar .
 
-CMD java -jar explorviz-landscape-service.jar
+USER explorviz
+CMD ["java", "-jar", "explorviz-landscape-service.jar"]

--- a/settings-service/Dockerfile
+++ b/settings-service/Dockerfile
@@ -1,17 +1,18 @@
-FROM openjdk:11-jre-slim
+FROM adoptopenjdk/openjdk11:alpine-jre
+
+RUN adduser -D -H explorviz
 
 ENV SERVICE_PREFIX settings
-
 ENV MONGO_HOST 127.0.0.1
 ENV MONGO_PORT 27019
 
-RUN mkdir /explorviz
-WORKDIR /explorviz
+WORKDIR /opt/explorviz
 COPY build/libs/explorviz-settings-service.jar .
-RUN mkdir META-INF
-COPY build/resources/main/explorviz.properties META-INF/explorviz-custom.properties
+COPY --chown=explorviz:explorviz build/resources/main/explorviz.properties META-INF/explorviz-custom.properties
 
+COPY entrypoint.sh .
 COPY prod-env-updater.sh .
-RUN chmod +x ./prod-env-updater.sh
 
-CMD ./prod-env-updater.sh && java -cp explorviz-settings-service.jar:META-INF net.explorviz.settings.server.main.Main
+USER explorviz
+ENTRYPOINT ["./entrypoint.sh"]
+CMD ["java", "-cp", "explorviz-settings-service.jar:META-INF", "net.explorviz.settings.server.main.Main"]

--- a/settings-service/entrypoint.sh
+++ b/settings-service/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -euo pipefail
+
+./prod-env-updater.sh
+
+exec "$@"

--- a/settings-service/prod-env-updater.sh
+++ b/settings-service/prod-env-updater.sh
@@ -1,5 +1,6 @@
+#!/bin/sh
+set -euo pipefail
+
 sed -i "s#mongo.host=.*#mongo.host=$MONGO_HOST#g" META-INF/explorviz-custom.properties
-
 sed -i "s#mongo.port=.*#mongo.port=$MONGO_PORT#g" META-INF/explorviz-custom.properties
-
 sed -i "s#service.prefix=.*#service.prefix=$SERVICE_PREFIX#g" META-INF/explorviz-custom.properties

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -1,9 +1,11 @@
-FROM openjdk:11-jre-slim
+FROM adoptopenjdk/openjdk11:alpine-jre
+
+RUN adduser -D -H explorviz
 
 ENV SERVICES_SETTINGS settings-service:8087
 
-RUN mkdir /explorviz
-WORKDIR /explorviz
+WORKDIR /opt/explorviz
 COPY build/libs/explorviz-user-service.jar .
 
-CMD java -jar explorviz-user-service.jar
+USER explorviz
+CMD ["java", "-jar", "explorviz-user-service.jar"]


### PR DESCRIPTION
- Switch from Oracle OpenJDK to AdoptOpenJDK based on alpine, lowering base
  image size from 204 MB to 141 MB
- Remove useless RUN mkdir statements and use FHS-compliant directory in /opt
  instead
- Change from the discouraged shell-based CMD to plain array CMDs, so there is
  no useless shell running our process as a child anymore
- Running as root within the container is bad practice. Instead create an
  unprivileged user and run as that. Since we have no volumes and don't bind
  to privileged ports no other modifications are necessary
- Use multi-stage build for analysis service so we do not need to ship the
  entire JDK in our final image
- Add missing executable flag to prod-env-updater.sh instead of chmod'ing it
  from inside the container and run it properly from an entrypoint script

These changes bring our image sizes down from:
```
openjdk                                         11-jre-slim  11 days ago         204MB
explorviz/explorviz-backend-user-service        dev          10 days ago         242MB
explorviz/explorviz-backend-settings-service    dev          10 days ago         242MB
explorviz/explorviz-backend-landscape-service   dev          10 days ago         238MB
explorviz/explorviz-backend-history-service     dev          10 days ago         243MB
explorviz/explorviz-backend-discovery-service   dev          10 days ago         242MB
explorviz/explorviz-backend-broadcast-service   dev          10 days ago         242MB
explorviz/explorviz-backend-analysis-service    dev          10 days ago         380MB
```
to
```
adoptopenjdk/openjdk11                          alpine-jre  7 days ago          141MB
explorviz/explorviz-backend-user-service        dev         4 seconds ago       180MB
explorviz/explorviz-backend-settings-service    dev         7 seconds ago       180MB
explorviz/explorviz-backend-landscape-service   dev         12 seconds ago      175MB
explorviz/explorviz-backend-history-service     dev         15 seconds ago      180MB
explorviz/explorviz-backend-discovery-service   dev         18 seconds ago      179MB
explorviz/explorviz-backend-broadcast-service   dev         20 seconds ago      180MB
explorviz/explorviz-backend-analysis-service    dev         52 seconds ago      234MB
```

I've tested this only briefly using the ExplorViz/sampleApplication.

Is the prod-env-updater.sh script for settings-service still being used? Our docker-compose files do not make use of these environment variables and we could get rid of some unnecessary complexity there.